### PR TITLE
fix: `Textarea` thrashing when autoSize is set

### DIFF
--- a/src/ResizableTextArea.tsx
+++ b/src/ResizableTextArea.tsx
@@ -43,6 +43,10 @@ class ResizableTextArea extends React.Component<TextAreaProps, TextAreaState> {
     this.textArea = textArea;
   };
 
+  componentDidMount(): void {
+    this.resizeTextarea();
+  }
+
   componentDidUpdate(prevProps: TextAreaProps) {
     // Re-render with the new content or new autoSize property then recalculate the height as required.
     if (

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -199,6 +199,11 @@ describe('TextArea', () => {
     expect(resizeTextarea).not.toHaveBeenCalled();
   });
 
+  it('calculate textarea size during mount hook', async () => {
+    const wrapper = mount(<TextArea value="A" autoSize />);
+    expect(wrapper.find('textarea').prop('style')).toHaveProperty('height');
+  });
+
   it('handleKeyDown', () => {
     const onPressEnter = jest.fn();
     const onKeyDown = jest.fn();


### PR DESCRIPTION
fix: https://github.com/ant-design/ant-design/issues/34683