### PR TITLE
fix: initialize height

### DIFF
--- a/src/ResizableTextArea.tsx
+++ b/src/ResizableTextArea.tsx
@@ -43,6 +43,13 @@ class ResizableTextArea extends React.Component<TextAreaProps, TextAreaState> {
     this.textArea = textArea;
   };
 
+  componentDidMount() {
+    // Initialize height.
+    if (this.props.autoSize) {
+      this.resizeTextarea();
+    }
+  }
+
   componentDidUpdate(prevProps: TextAreaProps) {
     // Re-render with the new content or new autoSize property then recalculate the height as required.
     if (


### PR DESCRIPTION
设置 autoSize 属性时当 height 小于或者大于初始的 height（30px）,Textarea 组件初始化时 height 会有抖动
ant-design 相关 issues： https://github.com/ant-design/ant-design/issues/36556

https://user-images.githubusercontent.com/38420763/181672334-2b800ca1-0905-4cdb-91fd-0d924c417450.mp4

<a href="https://codesandbox.io/s/nifty-flower-xqs2vo?file=/App.jsx" rel="nofollow"><img src="https://camo.githubusercontent.com/90808661433696bc57dce8d4ad732307b5cec6270e6b846f114dcd7ee7f9458a/68747470733a2f2f636f646573616e64626f782e696f2f7374617469632f696d672f706c61792d636f646573616e64626f782e737667" alt="Edit on CodeSandbox" data-canonical-src="https://codesandbox.io/static/img/play-codesandbox.svg" style="max-width: 100%;"></a>