### PR TITLE
Resolve conflict with onResize prop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import type { AutoSizeType } from './ResizableTextArea';
 export type HTMLTextareaProps =
   React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
-export interface TextAreaProps extends HTMLTextareaProps {
+export interface TextAreaProps extends Omit<HTMLTextareaProps, 'onResize'> {
   prefixCls?: string;
   className?: string;
   style?: React.CSSProperties;


### PR DESCRIPTION
A temporary solution to the conflict of the `onResize` prop.
A better solution will probably be to rename the `onResize` prop of `TextAreaProps` interface.
Solves: https://github.com/react-component/textarea/issues/25