### PR TITLE
fix: wrapper height should be auto when textarea has height

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -1,1 +1,14 @@
 @textarea-prefix-cls: rc-textarea;
+
+.rc-textarea-affix-wrapper {
+  display: inline-block;
+  box-sizing: border-box;
+  border: 1px solid #1677ff;
+
+  textarea {
+    box-sizing: border-box;
+    height: 100%;
+    padding: 0;
+    border: none;
+  }
+}

--- a/assets/index.less
+++ b/assets/index.less
@@ -3,12 +3,12 @@
 .rc-textarea-affix-wrapper {
   display: inline-block;
   box-sizing: border-box;
-  border: 1px solid #1677ff;
 
   textarea {
     box-sizing: border-box;
+    width: 100%;
     height: 100%;
     padding: 0;
-    border: none;
+    border: 1px solid #1677ff;
   }
 }

--- a/docs/demo/showCount.tsx
+++ b/docs/demo/showCount.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import Textarea from 'rc-textarea';
 import React, { useState } from 'react';
+import '../../assets/index.less';
 
 export default function App() {
   const [value, setValue] = useState('hello\nworld');
@@ -18,6 +19,13 @@ export default function App() {
       <Textarea autoSize showCount />
       <p>controlled</p>
       <Textarea value={value} onChange={onChange} showCount maxLength={100} />
+      <p>with height</p>
+      <Textarea
+        value={value}
+        onChange={onChange}
+        showCount
+        style={{ height: 200 }}
+      />
     </div>
   );
 }

--- a/docs/demo/showCount.tsx
+++ b/docs/demo/showCount.tsx
@@ -24,7 +24,7 @@ export default function App() {
         value={value}
         onChange={onChange}
         showCount
-        style={{ height: 200 }}
+        style={{ height: 200, width: '100%', resize: 'vertical' }}
       />
     </div>
   );

--- a/src/TextArea.tsx
+++ b/src/TextArea.tsx
@@ -76,7 +76,6 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     const [compositing, setCompositing] = React.useState(false);
     const oldCompositionValueRef = React.useRef<string>();
     const oldSelectionStartRef = React.useRef<number>(0);
-    // Since ResizeObserver would resize once on mounted, manual resizing should be happened after that
     const [textareaResized, setTextareaResized] = React.useState<boolean>(null);
 
     const focus = () => {

--- a/src/TextArea.tsx
+++ b/src/TextArea.tsx
@@ -77,9 +77,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     const oldCompositionValueRef = React.useRef<string>();
     const oldSelectionStartRef = React.useRef<number>(0);
     // Since ResizeObserver would resize once on mounted, manual resizing should be happened after that
-    const [resizeStatus, setResizeStatus] = React.useState<
-      'mounted' | 'resized' | null
-    >(null);
+    const [textareaResized, setTextareaResized] = React.useState<boolean>(null);
 
     const focus = () => {
       resizableTextAreaRef.current.textArea.focus();
@@ -224,10 +222,8 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
 
     const handleResize: TextAreaProps['onResize'] = (size) => {
       onResize?.(size);
-      if (resizeStatus === null) {
-        setResizeStatus('mounted');
-      } else if (resizeStatus === 'mounted') {
-        setResizeStatus('resized');
+      if (resizableTextAreaRef.current.textArea.style.height) {
+        setTextareaResized(true);
       }
     };
 
@@ -249,7 +245,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
         className={className}
         style={{
           ...style,
-          ...(resizeStatus === 'resized' ? { height: 'auto' } : {}),
+          ...(textareaResized ? { height: 'auto' } : {}),
         }}
         dataAttrs={{
           affixWrapper: {

--- a/src/TextArea.tsx
+++ b/src/TextArea.tsx
@@ -60,6 +60,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       hidden,
       classNames,
       styles,
+      onResize,
       ...rest
     },
     ref,
@@ -75,6 +76,10 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     const [compositing, setCompositing] = React.useState(false);
     const oldCompositionValueRef = React.useRef<string>();
     const oldSelectionStartRef = React.useRef<number>(0);
+    // Since ResizeObserver would resize once on mounted, manual resizing should be happened after that
+    const [resizeStatus, setResizeStatus] = React.useState<
+      'mounted' | 'resized' | null
+    >(null);
 
     const focus = () => {
       resizableTextAreaRef.current.textArea.focus();
@@ -217,6 +222,15 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       );
     }
 
+    const handleResize: TextAreaProps['onResize'] = (size) => {
+      onResize?.(size);
+      if (resizeStatus === null) {
+        setResizeStatus('mounted');
+      } else if (resizeStatus === 'mounted') {
+        setResizeStatus('resized');
+      }
+    };
+
     const textarea = (
       <BaseInput
         value={val}
@@ -233,7 +247,10 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
         disabled={disabled}
         focused={focused}
         className={className}
-        style={style}
+        style={{
+          ...style,
+          ...(resizeStatus === 'resized' ? { height: 'auto' } : {}),
+        }}
         dataAttrs={{
           affixWrapper: {
             'data-count': typeof dataCount === 'string' ? dataCount : undefined,
@@ -253,6 +270,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
             style={{ ...styles?.textarea, resize: style?.resize }}
             disabled={disabled}
             prefixCls={prefixCls}
+            onResize={handleResize}
             ref={resizableTextAreaRef}
           />
         }

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -384,13 +384,9 @@ describe('TextArea', () => {
         .style.height,
     ).toBe('200px');
 
-    triggerResize(container.querySelector('textarea'));
-    await wait();
-    expect(onResize).toHaveBeenCalledTimes(1);
-
     triggerResize(container.querySelector('textarea'), { height: 1000 });
     await wait();
-    expect(onResize).toHaveBeenCalledTimes(2);
+    expect(onResize).toHaveBeenCalledTimes(1);
     expect(
       (container.querySelector('.rc-textarea-affix-wrapper') as HTMLDivElement)
         .style.height,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -17,6 +17,7 @@ export function triggerResize(
   // @ts-ignore
   onEsResize([{ target }]);
 
+  target.style.height = `${height}px`;
   target.getBoundingClientRect = originGetBoundingClientRect;
 }
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,30 @@
+import { act } from '@testing-library/react';
+import {
+  _rs as onEsResize,
+  _rs as onLibResize,
+} from 'rc-resize-observer/lib/utils/observerUtil';
+
+export function triggerResize(
+  target,
+  size?: { width?: number; height?: number },
+) {
+  const { width = 510, height = 903 } = size || {};
+  const originGetBoundingClientRect = target.getBoundingClientRect;
+
+  target.getBoundingClientRect = () => ({ width, height });
+  // @ts-ignore
+  onLibResize([{ target }]);
+  // @ts-ignore
+  onEsResize([{ target }]);
+
+  target.getBoundingClientRect = originGetBoundingClientRect;
+}
+
+export async function wait() {
+  for (let i = 0; i < 100; i += 1) {
+    await act(async () => {
+      jest.runAllTimers();
+      await Promise.resolve();
+    });
+  }
+}


### PR DESCRIPTION
- Revert "Revert "fix: affixWrapper should be resized with textarea (#40)""
- fix: wrapper height should be auto when textarea has height

close https://github.com/ant-design/ant-design/issues/42846
