### PR TITLE
chore: bump rc-input from 1.5.0 to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@babel/runtime": "^7.10.1",
     "classnames": "^2.2.1",
-    "rc-input": "~1.5.0",
+    "rc-input": "~1.6.0",
     "rc-resize-observer": "^1.0.0",
     "rc-util": "^5.27.0"
   },


### PR DESCRIPTION
chore: bump rc-input from 1.5.0 to 1.6.0