### PR TITLE
fix: rm onPressEnter

### DIFF
--- a/src/ResizableTextArea.tsx
+++ b/src/ResizableTextArea.tsx
@@ -160,7 +160,7 @@ const ResizableTextArea = React.forwardRef<ResizableTextAreaRef, TextAreaProps>(
     // =============================== Render ===============================
     const mergedAutoSizeStyle = needAutoSize ? autoSizeStyle : null;
 
-    const mergedStyle = {
+    const mergedStyle: React.CSSProperties = {
       ...style,
       ...mergedAutoSizeStyle,
     };

--- a/src/TextArea.tsx
+++ b/src/TextArea.tsx
@@ -39,6 +39,8 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       onClear,
       onPressEnter,
       readOnly,
+      autoSize,
+      onKeyDown,
       ...rest
     },
     ref,
@@ -152,7 +154,6 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      const { onKeyDown } = rest;
       if (e.key === 'Enter' && onPressEnter) {
         onPressEnter(e);
       }
@@ -209,7 +210,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       }
     };
 
-    const isPureTextArea = !rest.autoSize && !showCount && !allowClear;
+    const isPureTextArea = !autoSize && !showCount && !allowClear;
 
     return (
       <BaseInput
@@ -244,6 +245,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       >
         <ResizableTextArea
           {...rest}
+          autoSize={autoSize}
           maxLength={maxLength}
           onKeyDown={handleKeyDown}
           onChange={onInternalChange}

--- a/src/TextArea.tsx
+++ b/src/TextArea.tsx
@@ -37,6 +37,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       styles,
       onResize,
       onClear,
+      onPressEnter,
       readOnly,
       ...rest
     },
@@ -151,7 +152,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      const { onPressEnter, onKeyDown } = rest;
+      const { onKeyDown } = rest;
       if (e.key === 'Enter' && onPressEnter) {
         onPressEnter(e);
       }

--- a/tests/ResizableTextArea.test.tsx
+++ b/tests/ResizableTextArea.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import type { ResizableTextAreaRef, TextAreaProps } from '../src';
+import { ResizableTextArea } from '../src';
+
+const resizableTextAreaProps = () => (global as any).textAreaProps;
+
+jest.mock('../src/ResizableTextArea', () => {
+  const ReactReal: typeof React = jest.requireActual('react');
+  const Resizable = jest.requireActual('../src/ResizableTextArea');
+  const ResizableComponent = Resizable.default;
+  return ReactReal.forwardRef<ResizableTextAreaRef, TextAreaProps>(
+    (props, ref) => {
+      (global as any).textAreaProps = props;
+      return <ResizableComponent {...props} ref={ref} />;
+    },
+  );
+});
+
+it('should have no onPressEnter prop', () => {
+  render(<ResizableTextArea defaultValue="test" />);
+  expect(resizableTextAreaProps().onPressEnter).toBeUndefined();
+});


### PR DESCRIPTION
提前解构 `onPressEnter`，避免被透传给子组件 textarea

![image](https://github.com/user-attachments/assets/e55e7365-a703-4385-ae74-ceee3d8f8057)