### PR TITLE
feat: Add IME judgment

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.1",
-    "@rc-component/input": "~1.0.0",
+    "@rc-component/input": "~1.1.0",
     "@rc-component/resize-observer": "^1.0.0",
     "@rc-component/util": "^1.2.0"
   },

--- a/src/TextArea.tsx
+++ b/src/TextArea.tsx
@@ -1,9 +1,9 @@
-import clsx from 'classnames';
 import { BaseInput } from '@rc-component/input';
 import { type HolderRef } from '@rc-component/input/lib/BaseInput';
 import useCount from '@rc-component/input/lib/hooks/useCount';
 import { resolveOnChange } from '@rc-component/input/lib/utils/commonUtils';
 import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
+import clsx from 'classnames';
 import type { ReactNode } from 'react';
 import React, { useEffect, useImperativeHandle, useRef } from 'react';
 import ResizableTextArea from './ResizableTextArea';
@@ -154,7 +154,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Enter' && onPressEnter) {
+      if (e.key === 'Enter' && onPressEnter && !e.nativeEvent.isComposing) {
         onPressEnter(e);
       }
       onKeyDown?.(e);

--- a/src/TextArea.tsx
+++ b/src/TextArea.tsx
@@ -1,9 +1,9 @@
+import clsx from 'classnames';
 import { BaseInput } from '@rc-component/input';
 import { type HolderRef } from '@rc-component/input/lib/BaseInput';
 import useCount from '@rc-component/input/lib/hooks/useCount';
 import { resolveOnChange } from '@rc-component/input/lib/utils/commonUtils';
 import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
-import clsx from 'classnames';
 import type { ReactNode } from 'react';
 import React, { useEffect, useImperativeHandle, useRef } from 'react';
 import ResizableTextArea from './ResizableTextArea';

--- a/tests/__snapshots__/allowClear.test.tsx.snap
+++ b/tests/__snapshots__/allowClear.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`should support allowClear should not show icon if defaultValue is undef
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       ✖
@@ -32,6 +33,7 @@ exports[`should support allowClear should not show icon if defaultValue is undef
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       ✖
@@ -52,6 +54,7 @@ exports[`should support allowClear should not show icon if defaultValue is undef
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       ✖
@@ -72,6 +75,7 @@ exports[`should support allowClear should not show icon if value is undefined, n
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       ✖
@@ -92,6 +96,7 @@ exports[`should support allowClear should not show icon if value is undefined, n
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       ✖
@@ -112,6 +117,7 @@ exports[`should support allowClear should not show icon if value is undefined, n
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       ✖

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -381,3 +381,45 @@ describe('TextArea', () => {
     });
   });
 });
+
+describe.only('TextArea IME behavior', () => {
+  it('should ignore Enter during composition', () => {
+    const onPressEnter = jest.fn();
+    const { container } = render(<TextArea onPressEnter={onPressEnter} />);
+    const textarea = container.querySelector('textarea')!;
+
+    fireEvent.compositionStart(textarea);
+
+    fireEvent.keyDown(textarea, {
+      key: 'Enter',
+      keyCode: 229,
+      isComposing: true,
+      nativeEvent: { isComposing: true },
+    });
+
+    fireEvent.compositionUpdate(textarea, { data: '开始' });
+
+    expect(onPressEnter).not.toHaveBeenCalled();
+
+    fireEvent.compositionEnd(textarea);
+    fireEvent.keyDown(textarea, {
+      key: 'Enter',
+      nativeEvent: { isComposing: false },
+    });
+    expect(onPressEnter).toHaveBeenCalledTimes(1);
+  });
+
+  it('should trigger Enter for non-composition (normal) input', () => {
+    const onPressEnter = jest.fn();
+    const { container } = render(<TextArea onPressEnter={onPressEnter} />);
+    const textarea = container.querySelector('textarea')!;
+
+    fireEvent.change(textarea, { target: { value: 'test' } });
+
+    fireEvent.keyDown(textarea, {
+      key: 'Enter',
+    });
+    expect(onPressEnter).toHaveBeenCalledTimes(1);
+    expect(textarea.value).toBe('test');
+  });
+});

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -382,7 +382,7 @@ describe('TextArea', () => {
   });
 });
 
-describe.only('TextArea IME behavior', () => {
+describe('TextArea IME behavior', () => {
   it('should ignore Enter during composition', () => {
     const onPressEnter = jest.fn();
     const { container } = render(<TextArea onPressEnter={onPressEnter} />);


### PR DESCRIPTION
增加 IME 组合输入时候，Enter键判断调用

close https://github.com/ant-design/ant-design/issues/54214 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了在使用输入法（IME）组合输入时，按下回车键不会错误触发 onPressEnter 回调的问题。

* **Tests**
  * 新增了针对输入法（IME）组合输入和回车键处理的测试用例，确保 onPressEnter 行为符合预期。

* **Chores**
  * 升级了依赖 @rc-component/input 至 ~1.1.0。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->