### PR TITLE
fix: fix Firefox scroll bug and improve TextArea tests

### DIFF
--- a/src/ResizableTextArea.tsx
+++ b/src/ResizableTextArea.tsx
@@ -1,8 +1,8 @@
-import classNames from 'classnames';
 import ResizeObserver from '@rc-component/resize-observer';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
 import raf from '@rc-component/util/lib/raf';
+import classNames from 'classnames';
 import * as React from 'react';
 import type { TextAreaProps } from '.';
 import calculateAutoSizeStyle from './calculateNodeHeight';
@@ -66,9 +66,10 @@ const ResizableTextArea = React.forwardRef<ResizableTextAreaRef, TextAreaProps>(
     // https://github.com/ant-design/ant-design/issues/21870
     const fixFirefoxAutoScroll = () => {
       try {
+        const isFirefox = navigator.userAgent.includes('Firefox');
         // FF has bug with jump of scroll to top. We force back here.
-        if (document.activeElement === textareaRef.current) {
-          const { selectionStart, selectionEnd, scrollTop } =
+        if (isFirefox && document.activeElement === textareaRef.current) {
+          const { scrollTop, selectionStart, selectionEnd } =
             textareaRef.current;
 
           // Fix Safari bug which not rollback when break line


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix https://github.com/ant-design/ant-design/issues/54444
close https://github.com/ant-design/ant-design/pull/54447
close https://github.com/react-component/textarea/pull/18

### 💡 Background and Solution
Input.Textarea cursor position error after pasting text
Listen to onPaste event and recalculate cursor position

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix textarea cursor position error after pasting text |
| 🇨🇳 Chinese | 修复粘贴文本后 textarea 光标位置错误 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了仅在 Firefox 浏览器下自动滚动行为异常的问题。

* **Tests**
  * 新增了关于粘贴多行文本后光标位置变化的测试用例。
  * 优化了自动高度调整时的滚动测试，提升了测试稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->