### PR TITLE
refactor: Upgrade utils and replace useMergedState

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "classnames": "^2.2.1",
     "@rc-component/input": "~1.0.0",
     "@rc-component/resize-observer": "^1.0.0",
-    "@rc-component/util": "^1.2.0"
+    "@rc-component/util": "^1.3.0"
   },
   "devDependencies": {
     "@rc-component/father-plugin": "^2.0.2",

--- a/src/ResizableTextArea.tsx
+++ b/src/ResizableTextArea.tsx
@@ -1,8 +1,8 @@
-import classNames from 'classnames';
 import ResizeObserver from '@rc-component/resize-observer';
+import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
-import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
 import raf from '@rc-component/util/lib/raf';
+import classNames from 'classnames';
 import * as React from 'react';
 import type { TextAreaProps } from '.';
 import calculateAutoSizeStyle from './calculateNodeHeight';
@@ -32,10 +32,10 @@ const ResizableTextArea = React.forwardRef<ResizableTextAreaRef, TextAreaProps>(
     };
 
     // =============================== Value ================================
-    const [mergedValue, setMergedValue] = useMergedState(defaultValue, {
-      value,
-      postState: (val) => val ?? '',
-    });
+    const [mergedValue, setMergedValue] = useControlledState(
+      defaultValue || '',
+      value || '',
+    );
 
     const onInternalChange: React.ChangeEventHandler<HTMLTextAreaElement> = (
       event,

--- a/src/ResizableTextArea.tsx
+++ b/src/ResizableTextArea.tsx
@@ -32,10 +32,11 @@ const ResizableTextArea = React.forwardRef<ResizableTextAreaRef, TextAreaProps>(
     };
 
     // =============================== Value ================================
-    const [mergedValue, setMergedValue] = useControlledState(
-      defaultValue || '',
-      value || '',
+    const [internalValue, setMergedValue] = useControlledState(
+      defaultValue,
+      value,
     );
+    const mergedValue = internalValue ?? '';
 
     const onInternalChange: React.ChangeEventHandler<HTMLTextAreaElement> = (
       event,

--- a/src/TextArea.tsx
+++ b/src/TextArea.tsx
@@ -45,11 +45,11 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     },
     ref,
   ) => {
-    const [internelValue, setValue] = useControlledState(
+    const [internalValue, setValue] = useControlledState(
       defaultValue,
       customValue,
     );
-    const value = internelValue || '';
+    const value = internalValue || '';
     const formatValue =
       value === undefined || value === null ? '' : String(value);
 

--- a/src/TextArea.tsx
+++ b/src/TextArea.tsx
@@ -45,11 +45,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     },
     ref,
   ) => {
-    const [internalValue, setValue] = useControlledState(
-      defaultValue,
-      customValue,
-    );
-    const value = internalValue || '';
+    const [value, setValue] = useControlledState(defaultValue, customValue);
     const formatValue =
       value === undefined || value === null ? '' : String(value);
 

--- a/src/TextArea.tsx
+++ b/src/TextArea.tsx
@@ -1,9 +1,9 @@
-import clsx from 'classnames';
 import { BaseInput } from '@rc-component/input';
 import { type HolderRef } from '@rc-component/input/lib/BaseInput';
 import useCount from '@rc-component/input/lib/hooks/useCount';
 import { resolveOnChange } from '@rc-component/input/lib/utils/commonUtils';
-import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
+import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
+import clsx from 'classnames';
 import type { ReactNode } from 'react';
 import React, { useEffect, useImperativeHandle, useRef } from 'react';
 import ResizableTextArea from './ResizableTextArea';
@@ -45,10 +45,11 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
     },
     ref,
   ) => {
-    const [value, setValue] = useMergedState(defaultValue, {
-      value: customValue,
+    const [internelValue, setValue] = useControlledState(
       defaultValue,
-    });
+      customValue,
+    );
+    const value = internelValue || '';
     const formatValue =
       value === undefined || value === null ? '' : String(value);
 

--- a/tests/__snapshots__/allowClear.test.tsx.snap
+++ b/tests/__snapshots__/allowClear.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`should support allowClear should not show icon if defaultValue is undef
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       ✖
@@ -32,6 +33,7 @@ exports[`should support allowClear should not show icon if defaultValue is undef
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       ✖
@@ -52,6 +54,7 @@ exports[`should support allowClear should not show icon if defaultValue is undef
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       ✖
@@ -72,6 +75,7 @@ exports[`should support allowClear should not show icon if value is undefined, n
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       ✖
@@ -92,6 +96,7 @@ exports[`should support allowClear should not show icon if value is undefined, n
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       ✖
@@ -112,6 +117,7 @@ exports[`should support allowClear should not show icon if value is undefined, n
   >
     <button
       class="rc-textarea-clear-icon rc-textarea-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       ✖


### PR DESCRIPTION
关联issue：https://github.com/ant-design/ant-design/issues/54854
替换 useMergedState 为 useControlledState


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新特性
  - 无
- Bug 修复
  - 提升 TextArea 与 ResizableTextArea 在受控/非受控切换时的稳定性，避免空值导致显示异常，输入值格式更一致
- 重构
  - 统一受控/非受控状态管理，简化内部逻辑，保持对外 API 不变
- 杂务
  - 将依赖 @rc-component/util 更新至 1.3.0，改善兼容性与细节行为
<!-- end of auto-generated comment: release notes by coderabbit.ai -->