### PR TITLE
fix: trigger onChange twice when using IME input

### DIFF
--- a/src/TextArea.tsx
+++ b/src/TextArea.tsx
@@ -6,12 +6,13 @@ import useControlledState from '@rc-component/util/lib/hooks/useControlledState'
 import { clsx } from 'clsx';
 import type { ReactNode } from 'react';
 import React, { useEffect, useImperativeHandle, useRef } from 'react';
-import ResizableTextArea from './ResizableTextArea';
 import type {
+  ChangeEventInfo,
   ResizableTextAreaRef,
   TextAreaProps,
   TextAreaRef,
 } from './interface';
+import ResizableTextArea from './ResizableTextArea';
 
 const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
   (
@@ -105,6 +106,7 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
         | React.ChangeEvent<HTMLTextAreaElement>
         | React.CompositionEvent<HTMLTextAreaElement>,
       currentValue: string,
+      info: ChangeEventInfo,
     ) => {
       let cutValue = currentValue;
 
@@ -124,6 +126,8 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
             getTextArea().selectionEnd || 0,
           ]);
         }
+      } else if (info.source === 'compositionEnd') {
+        return;
       }
       setValue(cutValue);
 
@@ -142,12 +146,12 @@ const TextArea = React.forwardRef<TextAreaRef, TextAreaProps>(
       HTMLTextAreaElement
     > = (e) => {
       compositionRef.current = false;
-      triggerChange(e, e.currentTarget.value);
+      triggerChange(e, e.currentTarget.value, { source: 'compositionEnd' });
       onCompositionEnd?.(e);
     };
 
     const onInternalChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      triggerChange(e, e.target.value);
+      triggerChange(e, e.target.value, { source: 'change' });
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -44,3 +44,7 @@ export type TextAreaRef = {
   blur: () => void;
   nativeElement: HTMLElement;
 };
+
+export interface ChangeEventInfo {
+  source: 'compositionEnd' | 'change';
+}


### PR DESCRIPTION
This PR addresses [issue #77](https://github.com/react-component/textarea/issues/77) .
The same solution as https://github.com/react-component/input/pull/61.
![test](https://github.com/user-attachments/assets/c2acabde-77d6-4075-88b2-2c6526aec4fe)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 改进了文本框对输入法（IME）输入事件的处理机制。系统现已能够准确识别不同的输入事件来源，防止在输入法组合转换过程中发生意外的状态更新，显著增强了中文、日文等多语言输入场景下的稳定性和用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->